### PR TITLE
Group only `metrics` queue

### DIFF
--- a/lib/sidekiq/grouping/middleware.rb
+++ b/lib/sidekiq/grouping/middleware.rb
@@ -2,7 +2,7 @@ module Sidekiq
   module Grouping
     class Middleware
       # just a proof of concept - ideally should be stored in config
-      GROUPED_QUEUE = 'metrics'
+      GROUPED_QUEUE = "metrics".freeze
 
       def call(worker_class, msg, queue, redis_pool = nil)
         return yield if (defined?(Sidekiq::Testing) && Sidekiq::Testing.inline?)
@@ -14,7 +14,7 @@ module Sidekiq
 
         retrying = msg["failed_at"].present?
 
-        return yield unless batch?(worker_class, queue)
+        return yield unless batch?(queue)
 
         if !(passthrough || retrying)
           add_to_batch(worker_class, queue, msg, redis_pool)
@@ -26,13 +26,12 @@ module Sidekiq
 
       private
 
-      def batch?(worker_class, queue)
+      def batch?(queue)
         queue == GROUPED_QUEUE
       end
 
       def add_to_batch(worker_class, queue, msg, redis_pool = nil)
-        Sidekiq::Grouping::Batch
-          .new(worker_class, queue, redis_pool)
+        Sidekiq::Grouping::Batch.new(worker_class, queue, redis_pool)
           .add(msg['args'])
 
         nil

--- a/lib/sidekiq/grouping/middleware.rb
+++ b/lib/sidekiq/grouping/middleware.rb
@@ -1,16 +1,11 @@
 module Sidekiq
   module Grouping
     class Middleware
+      # just a proof of concept - ideally should be stored in config
+      GROUPED_QUEUE = 'metrics'
+
       def call(worker_class, msg, queue, redis_pool = nil)
         return yield if (defined?(Sidekiq::Testing) && Sidekiq::Testing.inline?)
-
-        worker_class = worker_class.camelize.constantize if worker_class.is_a?(String)
-        options = worker_class.get_sidekiq_options
-
-        batch =
-          options.key?('batch_flush_size') ||
-          options.key?('batch_flush_interval') ||
-          options.key?('batch_size')
 
         passthrough =
           msg['args'] &&
@@ -19,7 +14,7 @@ module Sidekiq
 
         retrying = msg["failed_at"].present?
 
-        return yield unless batch
+        return yield unless batch?(worker_class, queue)
 
         if !(passthrough || retrying)
           add_to_batch(worker_class, queue, msg, redis_pool)
@@ -31,9 +26,13 @@ module Sidekiq
 
       private
 
+      def batch?(worker_class, queue)
+        queue == GROUPED_QUEUE
+      end
+
       def add_to_batch(worker_class, queue, msg, redis_pool = nil)
         Sidekiq::Grouping::Batch
-          .new(worker_class.name, queue, redis_pool)
+          .new(worker_class, queue, redis_pool)
           .add(msg['args'])
 
         nil

--- a/spec/modules/batch_spec.rb
+++ b/spec/modules/batch_spec.rb
@@ -6,7 +6,7 @@ describe Sidekiq::Grouping::Batch do
   context 'adding' do
     it 'must enqueue unbatched worker' do
        RegularWorker.perform_async('bar')
-       expect(RegularWorker).to have_enqueued_job('bar')
+       expect(RegularWorker).to have_enqueued_sidekiq_job('bar')
     end
 
     it 'must not enqueue batched worker' do
@@ -67,7 +67,7 @@ describe Sidekiq::Grouping::Batch do
       expect(batch.could_flush?).to be_falsy
       10.times { |n| BatchedSizeWorker.perform_async("bar#{n}") }
       batch.flush
-      expect(BatchedSizeWorker).to have_enqueued_job([["bar0"], ["bar1"]])
+      expect(BatchedSizeWorker).to have_enqueued_sidekiq_job([["bar0"], ["bar1"]])
       expect(batch.size).to eq(7)
     end
   end
@@ -124,7 +124,7 @@ describe Sidekiq::Grouping::Batch do
 
   private
   def expect_batch(klass, queue)
-    expect(klass).to_not have_enqueued_job('bar')
+    expect(klass).to_not have_enqueued_sidekiq_job('bar')
     batch = subject.new(klass.name, queue)
     stats = subject.all
     expect(batch.size).to eq(1)


### PR DESCRIPTION
We need so that this gem won't try using `constantize` on jobs from different repos. 
We also don't want to lose performance.